### PR TITLE
[MediaBundle] Only get soundcloud thumbnail if api key is available

### DIFF
--- a/src/Kunstmaan/MediaBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/MediaBundle/DependencyInjection/Configuration.php
@@ -26,7 +26,7 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->scalarNode('soundcloud_api_key')->defaultValue('YOUR_CLIENT_ID')->end()
+                ->scalarNode('soundcloud_api_key')->defaultNull()->end()
                 ->arrayNode('remote_video')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/src/Kunstmaan/MediaBundle/Helper/RemoteAudio/RemoteAudioHandler.php
+++ b/src/Kunstmaan/MediaBundle/Helper/RemoteAudio/RemoteAudioHandler.php
@@ -103,14 +103,16 @@ class RemoteAudioHandler extends AbstractMediaHandler
         // update thumbnail
         switch ($audio->getType()) {
             case 'soundcloud':
-                $scData = json_decode(
-                    file_get_contents(
-                        'http://api.soundcloud.com/tracks/' . $code . '.json?client_id=' . $this->getSoundcloudApiKey()
-                    )
-                );
-                $artworkUrl = $scData->artwork_url;
-                $artworkUrl = str_replace('large.jpg', 't500x500.jpg', $artworkUrl);
-                $audio->setThumbnailUrl($artworkUrl);
+                if ($this->getSoundcloudApiKey()) {
+                    $scData = json_decode(
+                        file_get_contents(
+                            'http://api.soundcloud.com/tracks/' . $code . '.json?client_id=' . $this->getSoundcloudApiKey()
+                        )
+                    );
+                    $artworkUrl = $scData->artwork_url;
+                    $artworkUrl = str_replace('large.jpg', 't500x500.jpg', $artworkUrl);
+                    $audio->setThumbnailUrl($artworkUrl);
+                }
 
                 break;
         }

--- a/src/Kunstmaan/MediaBundle/Tests/DependencyInjection/KunstmaanMediaExtensionTest.php
+++ b/src/Kunstmaan/MediaBundle/Tests/DependencyInjection/KunstmaanMediaExtensionTest.php
@@ -20,7 +20,7 @@ class KunstmaanMediaExtensionTest extends AbstractExtensionTestCase
     {
         $this->load(['enable_pdf_preview' => true]);
 
-        $this->assertContainerBuilderHasParameter('kunstmaan_media.soundcloud_api_key', 'YOUR_CLIENT_ID');
+        $this->assertContainerBuilderHasParameter('kunstmaan_media.soundcloud_api_key', null);
         $this->assertContainerBuilderHasParameter('kunstmaan_media.remote_video');
         $this->assertContainerBuilderHasParameter('kunstmaan_media.enable_pdf_preview', true);
         $this->assertContainerBuilderHasParameter('kunstmaan_media.blacklisted_extensions');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | comma separated list of tickets fixed by the PR

Soundcloud triggered an error because of the api key and you cannot get new keys. So I changed the default value to null and add a check for getting the thumbnail url. 

Official reaction from soundcloud:

> ”Unfortunately we're currently not accepting any new developer requests for API keys and don't have an ETA of when it will be open again. As this is something to be decided and handled by the engineering side of the organisation- any updates will be posted on the developer blog https://developers.soundcloud.com/blog.”
